### PR TITLE
Generic id container

### DIFF
--- a/.github/workflows/create-py-mac-release.yaml
+++ b/.github/workflows/create-py-mac-release.yaml
@@ -36,6 +36,6 @@ jobs:
         env:
           MATURIN_PASSWORD: ${{ secrets.PYPI_PASS }}
         with:
-          maturin-version: 0.12.6
+          maturin-version: 0.13.3
           command: publish
           args: -m py-gaoya/Cargo.toml --no-sdist --universal2 -o wheels -i python  --username serenky

--- a/.github/workflows/create-py-window-release.yaml
+++ b/.github/workflows/create-py-window-release.yaml
@@ -35,6 +35,6 @@ jobs:
           MATURIN_PASSWORD: ${{ secrets.PYPI_PASS }}
           RUSTFLAGS: '-C target-feature=+fxsr,+sse,+sse2,+sse3,+ssse3,+sse4.1,+popcnt'
         with:
-          maturin-version: 0.12.6
+          maturin-version: 0.13.3
           command: publish
           args: -m py-gaoya/Cargo.toml --no-sdist --universal2 -o wheels -i python --username serenky

--- a/gaoya/Cargo.toml
+++ b/gaoya/Cargo.toml
@@ -22,10 +22,10 @@ path = "src/lib.rs"
 bench = false
 
 [dependencies]
-ahash = "0.7.6"
+ahash = "0.8.0"
 rand = "0.8.5"
 rand_pcg = "0.3.1"
-sha-1 = "0.9.8"
+sha-1 = "0.10.0"
 siphasher = "0.3.10"
 random_choice = "0.3.2"
 rayon = "1.5.3"

--- a/gaoya/Cargo.toml
+++ b/gaoya/Cargo.toml
@@ -33,6 +33,7 @@ seahash = "4.1.0"
 itertools = "0.10.3"
 num-traits = "0.2.15"
 shingles = "0.1.1"
+smallvec = { version = "1.9.0", features = ["const_generics", "const_new"] }
 crossbeam-utils = "0.8.10"
 triomphe = "0.1.7"
 fnv = "1.0.7"

--- a/gaoya/src/minhash/id_container.rs
+++ b/gaoya/src/minhash/id_container.rs
@@ -1,0 +1,146 @@
+use std::collections::HashSet;
+use std::hash::{BuildHasher, Hash};
+use std::ops::Index;
+use std::slice::Iter;
+use smallvec::{Array, SmallVec};
+use crate::minhash::MinHashType;
+
+/// Container trait to hold point ids in MinHashIndex.
+///
+/// MinHashIndex stores id of every point in every band, where a band is roughly
+/// a HashMap<Hash, IdContainer<Id>>. MinHashing requires many bands (20 - 50) for optimal
+/// recall.
+///
+/// To support efficient removals use `HashSetContainer` which is backed up by `HashSet`
+/// If removals are not required or infrequent use `VecContainer`, which is faster and uses less memory.
+/// If the number of similar points is expected to be small use `SmallVecContainer`, which
+/// is backed up by `SmallVec`. `SmallVec` stores small number of elements inline in an array, and
+/// falls back to heap when inline array is full.
+///
+pub trait IdContainer<T>: Sync + Send {
+
+    fn new() -> Self;
+
+    fn push(&mut self, item: T);
+
+    fn len(&self) -> usize;
+
+    fn copy_to<S: BuildHasher>(&self, set: &mut HashSet<T, S>);
+
+    fn copy_refs_to<'a, S: BuildHasher>(&'a self, set: &mut HashSet<&'a T, S>);
+
+    fn remove(&mut self, item: &T);
+
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+
+pub struct HashSetContainer<T> {
+    set: HashSet<T>
+}
+
+impl<T: Hash + Eq + Send + Sync + Clone> IdContainer<T> for HashSetContainer<T> {
+
+    fn new() -> Self {
+        HashSetContainer {
+            set: HashSet::new()
+        }
+    }
+    fn push(&mut self, item: T) {
+        self.set.insert(item);
+    }
+
+    fn len(&self) -> usize {
+        self.set.len()
+    }
+
+    fn copy_to<S: BuildHasher>(&self, set: &mut HashSet<T, S>) {
+        set.extend(self.set.iter().cloned());
+    }
+
+    fn copy_refs_to<'a, S: BuildHasher>(&'a self, set: &mut HashSet<&'a T, S>) {
+        set.extend(self.set.iter())
+    }
+
+
+    fn remove(&mut self, item: &T) {
+        self.set.remove(item);
+    }
+}
+
+pub struct VecContainer<T> {
+    vec: Vec<T>
+}
+
+impl<T: Hash + Eq + Send + Sync + Clone> IdContainer<T> for  VecContainer<T> {
+    fn new() -> Self {
+        Self {
+            vec: Vec::new()
+        }
+    }
+
+    fn push(&mut self, item: T) {
+        self.vec.push(item);
+    }
+
+    fn len(&self) -> usize {
+        self.vec.len()
+    }
+
+    fn copy_to<S: BuildHasher>(&self, set: &mut HashSet<T, S>) {
+        set.extend(self.vec.iter().cloned())
+    }
+
+    fn copy_refs_to<'a, S: BuildHasher>(&'a self, set: &mut HashSet<&'a T, S>) {
+        set.extend(self.vec.iter())
+    }
+
+
+
+    fn remove(&mut self, item: &T) {
+        if let Some(index) =  self.vec.iter().position(|x| x == item) {
+            self.vec.swap_remove(index);
+        }
+    }
+}
+
+
+/// SmallVecContainer uses SmallVec backed up by an array
+pub struct SmallVecContainer<T, const N: usize> {
+    vec: SmallVec<[T; N]>
+}
+
+impl<T: Hash + Eq + Send + Sync + Clone, const N: usize> IdContainer<T> for SmallVecContainer<T, N> {
+    fn new() -> Self {
+        SmallVecContainer {
+            vec: SmallVec::<[T; N]>::new()
+        }
+    }
+
+    fn push(&mut self, item: T) {
+        self.vec.push(item);
+    }
+
+    fn len(&self) -> usize {
+        self.vec.len()
+    }
+
+    fn copy_to<S: BuildHasher>(&self, set: &mut HashSet<T, S>) {
+        set.extend(self.vec.iter().cloned())
+    }
+
+    fn copy_refs_to<'a, S: BuildHasher>(&'a self, container: &mut HashSet<&'a T, S>) {
+        container.extend(self.vec.iter())
+    }
+
+
+
+    fn remove(&mut self, item: &T) {
+        if let Some(index) = self.vec.iter().position(|x| x == item) {
+            self.vec.swap_remove(index);
+        };
+    }
+}
+

--- a/gaoya/src/minhash/min_hasher.rs
+++ b/gaoya/src/minhash/min_hasher.rs
@@ -43,7 +43,7 @@ macro_rules! make_min_hasher {
                 let rand_range1 = Uniform::from(1..MERSENNE_PRIME_31);
                 let rand_range2 = Uniform::from(0..MERSENNE_PRIME_31);
                 $name {
-                    build_hasher: build_hasher,
+                    build_hasher,
                     a: (0..num_hashes)
                         .map(|_| rand_range1.sample(&mut rng))
                         .collect(),

--- a/gaoya/src/minhash/mod.rs
+++ b/gaoya/src/minhash/mod.rs
@@ -5,6 +5,7 @@ mod min_hasher64;
 mod minhash_index;
 mod string_index;
 mod super_min_hash;
+mod id_container;
 
 
 pub use self::hashers::SipHasher24BuildHasher;
@@ -15,6 +16,10 @@ pub use self::min_hasher::MinHasher16;
 pub use self::min_hasher::MinHasher32;
 pub use self::minhash_index::MinHashIndex;
 pub use self::string_index::MinHashStringIndex;
+pub use self::id_container::IdContainer;
+pub use self::id_container::HashSetContainer;
+pub use self::id_container::SmallVecContainer;
+pub use self::id_container::VecContainer;
 use std::collections::{HashMap, HashSet};
 use std::hash::Hash;
 use std::iter::FromIterator;

--- a/py-gaoya/Cargo.toml
+++ b/py-gaoya/Cargo.toml
@@ -24,7 +24,7 @@ classifier = [
 
 [dependencies]
 libc = "0.2.106"
-pyo3 = { version = "0.16.5", features = ["extension-module", "abi3-py37"] }
+pyo3 = { version = "0.17.1", features = ["extension-module", "abi3-py37"] }
 rayon = "1.5.3"
 shingles = "0.1.1"
 fnv = "1.0.7"

--- a/py-gaoya/tests/test_minhash.py
+++ b/py-gaoya/tests/test_minhash.py
@@ -12,43 +12,46 @@ def test_minhash_64bit():
     assert index.query("a b g h f") == []
 
 
+def do_test_minhash(index):
+    index.insert_document(1, "a b c d e f")
+    index.insert_document(2, "1 2 3 4 5 6 8")
+
+    assert index.query(" a b c d e f") == [1]
+    assert index.query(" a b c d e g") == [1]
+    assert index.query("a b h g f") == []
+
+    assert index.query("1 2 3 4 5 6 8") == [2]
+    assert index.query("1 2 3 4 5 6 9 10") == [2]
+
+    index.remove(1)
+    assert index.query(" a b c d e f") == []
+
+
+def _test_min_hash(hash_len):
+    index = MinHashStringIndex(hash_len, 0.5, 30, 5)
+    do_test_minhash(index)
+
+    index = MinHashStringIndex(hash_len, 0.5, 30, 5, id_container="vec")
+    do_test_minhash(index)
+
+    index = MinHashStringIndex(hash_len, 0.5, 30, 5, id_container="smallvec")
+    do_test_minhash(index)
+
+    try:
+        index = MinHashStringIndex(hash_len, 0.5, 30, 5, id_container="array")
+        assert False, "id_container array is not supported"
+    except Exception as e:
+        assert type(e) == ValueError
+
 
 def test_minhash_32bit():
-    index = MinHashStringIndex(32, 0.5, 30, 5)
-    index.insert_document(1, "a b c d e f")
-    index.insert_document(2, "1 2 3 4 5 6 8")
-
-    assert index.query(" a b c d e f") == [1]
-    assert index.query(" a b c d e g") == [1]
-    assert index.query("a b h g f") == []
-
-    assert index.query("1 2 3 4 5 6 8") == [2]
-    assert index.query("1 2 3 4 5 6 9 10") == [2]
+    _test_min_hash(32)
 
 def test_minhash_16bit():
-    index = MinHashStringIndex(16, 0.5, 30, 5)
-    index.insert_document(1, "a b c d e f")
-    index.insert_document(2, "1 2 3 4 5 6 8")
-
-    assert index.query(" a b c d e f") == [1]
-    assert index.query(" a b c d e g") == [1]
-    assert index.query("a b h g f") == []
-
-    assert index.query("1 2 3 4 5 6 8") == [2]
-    assert index.query("1 2 3 4 5 6 9 10") == [2]
-
+    _test_min_hash(16)
 
 def test_minhash_8bit():
-    index = MinHashStringIndex(8, 0.5, 30, 5)
-    index.insert_document(1, "a b c d e f")
-    index.insert_document(2, "1 2 3 4 5 6 8")
-
-    assert index.query(" a b c d e f") == [1]
-    assert index.query(" a b c d e g") == [1]
-    assert index.query("a b h g f") == []
-
-    assert index.query("1 2 3 4 5 6 8") == [2]
-    assert index.query("1 2 3 4 5 6 9 10") == [2]
+    _test_min_hash(8)
 
 def test_minhash_16bit_custom_analyzer():
     def split_and_uppercase(doc):


### PR DESCRIPTION
Allow vector and smallvec to be used as container for ids. Vec is great for append only indexes. Smallvec can reduce memory usage when the number of near dups is very low and most items are unique